### PR TITLE
Fix portfolio taxonomy slug

### DIFF
--- a/inc/cpts.php
+++ b/inc/cpts.php
@@ -82,7 +82,8 @@ function portfolio() {
 		'description'           => __( 'Post Type Description', 'ch-infinity' ),
 		'labels'                => $labels,
 		'supports'              => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'page-attributes' ),
-		'taxonomies'            => array( 'post_tag', 'genres' ),
+                // Associate the custom Genre taxonomy correctly
+                'taxonomies'            => array( 'post_tag', 'genre' ),
 		'hierarchical'          => true,
 		'public'                => true,
 		'show_ui'               => true,


### PR DESCRIPTION
## Summary
- fix portfolio CPT to use `genre` taxonomy instead of nonexistent `genres`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6847235bc1788333b4593e8692ecd148